### PR TITLE
fix(editor) Fix overflow of pre tag in insights

### DIFF
--- a/src/components/Editor/Text.svelte
+++ b/src/components/Editor/Text.svelte
@@ -242,6 +242,10 @@
       margin: 5px 0 0;
     }
 
+    .md-block-code-block {
+      white-space: normal;
+    }
+
     @keyframes fade {
       from {
         opacity: 0;


### PR DESCRIPTION
## Summary
Workaround for overflow of `pre` html tag

The problem presumably occurs in case user pastes text with `pre` tags in it. Example: https://insights.santiment.net/read/alts-season-in-search-of-narrative-7955

## Screenshots
![image](https://github.com/user-attachments/assets/400839de-23aa-448a-aa70-0e5249c4f2f2)
