### PR TITLE
feat(insights) Add redirects to sanbase insights

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,33 +1,33 @@
 <script context="module">
-  import { queryAllInsightsSSR } from '@/api/insights'
-  import { queryFeaturedInsightsSSR } from '@/api/insights/featured'
-
-  const parseTags = (tags) => tags && tags.toUpperCase().split(',')
-  const parseFlag = (flag) => flag !== undefined
+  // import { queryAllInsightsSSR } from '@/api/insights'
+  // import { queryFeaturedInsightsSSR } from '@/api/insights/featured'
+  import { getSanbaseHref, feedQueryToSanbaseSearch } from '@/utils/url'
 
   export async function preload(page) {
     const { query } = page
 
-    const tags = parseTags(query.tags)
-    const onlyPro = parseFlag(query.onlyPro)
-    const isPulse = query.isPulse
+    this.redirect(303, getSanbaseHref(`/insights${feedQueryToSanbaseSearch(query)}`))
 
-    const insights = await queryAllInsightsSSR(1, tags, onlyPro, isPulse, this).catch((e) => {
-      console.log('Insights error', e)
-      return []
-    })
+    // const tags = parseTags(query.tags)
+    // const onlyPro = parseFlag(query.onlyPro)
+    // const isPulse = query.isPulse
 
-    const featured = await queryFeaturedInsightsSSR(this).catch((e) => {
-      console.log('Featured insights error', e)
-      return []
-    })
+    // const insights = await queryAllInsightsSSR(1, tags, onlyPro, isPulse, this).catch((e) => {
+    //   console.log('Insights error', e)
+    //   return []
+    // })
 
-    return {
-      insights,
-      onlyPro,
-      tags,
-      featured,
-    }
+    // const featured = await queryFeaturedInsightsSSR(this).catch((e) => {
+    //   console.log('Featured insights error', e)
+    //   return []
+    // })
+
+    // return {
+    //   insights,
+    //   onlyPro,
+    //   tags,
+    //   featured,
+    // }
   }
 </script>
 

--- a/src/routes/login/email.svelte
+++ b/src/routes/login/email.svelte
@@ -1,3 +1,11 @@
+<script context="module">
+  import { getSanbaseHref } from '@/utils/url'
+
+  export function preload() {
+    this.redirect(303, getSanbaseHref(`/login?from=${encodeURIComponent('/insights')}`))
+  }
+</script>
+
 <script>
   import EmailLogin from 'webkit/ui/LoginPrompt/EmailLogin.svelte'
 </script>

--- a/src/routes/login/index.svelte
+++ b/src/routes/login/index.svelte
@@ -1,3 +1,11 @@
+<script context="module">
+  import { getSanbaseHref } from '@/utils/url'
+
+  export function preload() {
+    this.redirect(303, getSanbaseHref(`/login?from=${encodeURIComponent('/insights')}`))
+  }
+</script>
+
 <script>
   // import { goto } from '@sapper/app'
   import LoginPrompt from 'webkit/ui/LoginPrompt/index.svelte'

--- a/src/routes/my/drafts.svelte
+++ b/src/routes/my/drafts.svelte
@@ -1,23 +1,27 @@
 <script context="module">
-  import { redirectToLoginPage } from '@/flow/redirect'
-  import { queryDraftInsights, queryDraftInsightsSSR } from '@/api/insights/user'
+  // import { redirectToLoginPage } from '@/flow/redirect'
+  // import { queryDraftInsights, queryDraftInsightsSSR } from '@/api/insights/user'
+  import { getSanbaseHref } from '@/utils/url'
 
   const onlyDrafts = ({ readyState }) => readyState === 'draft'
 
-  export async function preload(_, session) {
-    if (redirectToLoginPage(this, session)) return
+  export async function preload() {
+    this.redirect(303, getSanbaseHref('/insights/my?tab=drafts'))
 
-    const insights = await queryDraftInsightsSSR(1, this).catch((e) => {
-      console.log("User's draft insights error", e)
-      return []
-    })
+    // if (redirectToLoginPage(this, session)) return
 
-    return { insights: insights.filter(onlyDrafts) }
+    // const insights = await queryDraftInsightsSSR(1, this).catch((e) => {
+    //   console.log("User's draft insights error", e)
+    //   return []
+    // })
+
+    // return { insights: insights.filter(onlyDrafts) }
   }
 </script>
 
 <script>
   import ViewportPagination from '@cmp/ViewportPagination.svelte'
+  import { queryDraftInsights } from '@/api/insights/user'
   import Draft from '@cmp/InsightCard/Draft.svelte'
   import Empty from './_Empty.svelte'
 

--- a/src/routes/my/index.svelte
+++ b/src/routes/my/index.svelte
@@ -1,26 +1,30 @@
 <script context="module">
-  import { redirectToLoginPage } from '@/flow/redirect'
-  import { queryUserInsights, queryUserInsightsSSR } from '@/api/insights/user'
+  // import { redirectToLoginPage } from '@/flow/redirect'
+  // import { queryUserInsights, queryUserInsightsSSR } from '@/api/insights/user'
+  import { getSanbaseHref } from '@/utils/url'
 
   const onlyPublishedFilter = ({ readyState }) => readyState === 'published'
 
-  export async function preload(_, session) {
-    if (redirectToLoginPage(this, session)) return
+  export async function preload() {
+    this.redirect(303, getSanbaseHref('/insights/my'))
 
-    const userId = session.currentUser && session.currentUser.id
+    // if (redirectToLoginPage(this, session)) return
 
-    return {
-      userId,
-      insights: await queryUserInsightsSSR(1, userId, this).catch((e) => {
-        console.log("User's insights error", e)
-        return []
-      }),
-    }
+    // const userId = session.currentUser && session.currentUser.id
+
+    // return {
+    //   userId,
+    //   insights: await queryUserInsightsSSR(1, userId, this).catch((e) => {
+    //     console.log("User's insights error", e)
+    //     return []
+    //   }),
+    // }
   }
 </script>
 
 <script>
   import InsightsFeed from '@cmp/InsightsFeed.svelte'
+  import { queryUserInsights } from '@/api/insights/user'
   import Empty from './_Empty.svelte'
 
   export let userId = 0

--- a/src/routes/pulse.svelte
+++ b/src/routes/pulse.svelte
@@ -1,17 +1,20 @@
 <script context="module">
-  import { queryAllInsightsSSR } from '@/api/insights'
+  // import { queryAllInsightsSSR } from '@/api/insights'
+  import { getSanbaseHref, feedQueryToSanbaseSearch } from '@/utils/url'
 
-  const parseTags = (tags) => tags && tags.toUpperCase().split(',')
-  const parseOnlyPro = (onlyPro) => onlyPro !== undefined
+  // const parseTags = (tags) => tags && tags.toUpperCase().split(',')
+  // const parseOnlyPro = (onlyPro) => onlyPro !== undefined
 
   export async function preload(page) {
     const { query } = page
 
-    const tags = parseTags(query.tags)
-    const onlyPro = parseOnlyPro(query.onlyPro)
-    const insights = await queryAllInsightsSSR(1, tags, onlyPro, true, this)
+    this.redirect(303, getSanbaseHref(`/insights${feedQueryToSanbaseSearch(query)}`))
 
-    return { insights, onlyPro, tags }
+    // const tags = parseTags(query.tags)
+    // const onlyPro = parseOnlyPro(query.onlyPro)
+    // const insights = await queryAllInsightsSSR(1, tags, onlyPro, true, this)
+
+    // return { insights, onlyPro, tags }
   }
 </script>
 

--- a/src/routes/read/[slug].svelte
+++ b/src/routes/read/[slug].svelte
@@ -1,43 +1,46 @@
 <script context="module">
-  import { getIdFromSEOLink } from 'webkit/utils/url'
-  import { queryInsightSSR } from '@/api/insights'
-  import { RELATED_PROJECT_FRAGMENT, queryPriceDataSSR } from '@/api/insights/project'
-  import { redirectNonAuthor } from '@/flow/redirect'
+  // import { getIdFromSEOLink } from 'webkit/utils/url'
+  // import { queryInsightSSR } from '@/api/insights'
+  // import { RELATED_PROJECT_FRAGMENT, queryPriceDataSSR } from '@/api/insights/project'
+  // import { redirectNonAuthor } from '@/flow/redirect'
+  import { getSanbaseHref } from '@/utils/url'
 
-  export async function preload(page, session) {
-    const { currentUser, isMobile } = session
+  export async function preload(page) {
     const { slug } = page.params
-    console.log(`[DEBUG] Loading ${page.path}...`)
 
-    const id = getIdFromSEOLink(slug)
-    const DATA = isMobile ? undefined : RELATED_PROJECT_FRAGMENT
-    const insight = await queryInsightSSR(id, DATA, this).catch((e) => {
-      console.log("Insight doesn't exist", e)
-    })
+    this.redirect(303, getSanbaseHref(`/insights/read/${slug}`))
+    // const { currentUser, isMobile } = session
+    // console.log(`[DEBUG] Loading ${page.path}...`)
 
-    if (!insight) {
-      console.log('[DEBUG] Insight not found. Redirecting to /', { slug })
-      return this.redirect(302, '/')
-    }
+    // const id = getIdFromSEOLink(slug)
+    // const DATA = isMobile ? undefined : RELATED_PROJECT_FRAGMENT
+    // const insight = await queryInsightSSR(id, DATA, this).catch((e) => {
+    //   console.log("Insight doesn't exist", e)
+    // })
 
-    const isDraft = insight.readyState === 'draft'
-    if (isDraft && redirectNonAuthor(this, session, insight)) {
-      console.log('[DEBUG] Unauthorized draft access. Redirected to /', { slug })
-      return
-    }
+    // if (!insight) {
+    //   console.log('[DEBUG] Insight not found. Redirecting to /', { slug })
+    //   return this.redirect(302, '/')
+    // }
 
-    const { user, project, updatedAt } = insight
-    const publishedAt = insight.publishedAt || updatedAt
-    const isAuthor = currentUser && +currentUser.id === +user.id
+    // const isDraft = insight.readyState === 'draft'
+    // if (isDraft && redirectNonAuthor(this, session, insight)) {
+    //   console.log('[DEBUG] Unauthorized draft access. Redirected to /', { slug })
+    //   return
+    // }
 
-    // const queryPriceData = (...args) => queryPriceDataSSR(...args, this)
-    // const priceQuery =
-    //   project && queryPriceSincePublication(project.slug, publishedAt, queryPriceData)
+    // const { user, project, updatedAt } = insight
+    // const publishedAt = insight.publishedAt || updatedAt
+    // const isAuthor = currentUser && +currentUser.id === +user.id
 
-    // const projectData = await priceQuery
+    // // const queryPriceData = (...args) => queryPriceDataSSR(...args, this)
+    // // const priceQuery =
+    // //   project && queryPriceSincePublication(project.slug, publishedAt, queryPriceData)
 
-    console.log('[DEBUG] Insight data loaded successfully', { slug })
-    return { insight, projectSlug: project && project.slug, publishedAt, slug, isAuthor, isDraft }
+    // // const projectData = await priceQuery
+
+    // console.log('[DEBUG] Insight data loaded successfully', { slug })
+    // return { insight, projectSlug: project && project.slug, publishedAt, slug, isAuthor, isDraft }
   }
 </script>
 
@@ -142,7 +145,8 @@
         top
         options={{ rootMargin: '160px 0px -135px' }}
         on:intersect={hideSidebar}
-        on:leaving={showSidebar}>
+        on:leaving={showSidebar}
+      >
         <Epilogue {insight} {link} {isDraft} {isAuthor} {isFollowing} />
       </ViewportObserver>
 

--- a/src/routes/sign-up.svelte
+++ b/src/routes/sign-up.svelte
@@ -1,16 +1,8 @@
 <script context="module">
-  import { redirectLoggedInUser } from '@/flow/redirect'
+  // import { redirectLoggedInUser } from '@/flow/redirect'
+  import { getSanbaseHref } from '@/utils/url'
 
-  export function preload(_, session) {
-    redirectLoggedInUser(this, session)
+  export function preload() {
+    this.redirect(303, getSanbaseHref(`/sign-up?from=${encodeURIComponent('/insights')}`))
   }
 </script>
-
-<script>
-  import SignUp from 'webkit/ui/LoginPrompt/SignUp.svelte'
-  import Layout from './login/_layout.svelte'
-</script>
-
-<Layout>
-  <SignUp title="Welcome to Insights" />
-</Layout>

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,21 @@
+/**
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+export function getSanbaseHref(path) {
+  const stage = process.env.IS_STAGE_BACKEND ? '-stage' : ''
+  return `https://app${stage}.santiment.net${path}`
+}
+
+export function feedQueryToSanbaseSearch({ tags, onlyPro }) {
+  if (onlyPro) {
+    return '?tab=pro'
+  }
+
+  if (tags) {
+    return `?tags=${tags}`
+  }
+
+  return ''
+}


### PR DESCRIPTION
## Summary

Add redirects to sanbase new version of insights:
- `/` and `/pulse` both are redirected to Sanbase `/insights`
  - `tags` and `pro` filters are adapted for Sanbase
- `/login` and `/login/email` are redirected to sanbase `/login` page with `from` param set to `/__insights/feed`
- `/sign-up` is redirected to sanbase `/sign-up` page with `from` param set to `/__insights/feed`
- `/my` is redirected to Sanbase `/insights/my`
- `/my/drafts` is redirected to Sanbase `/insights/my?tab=drafts`
- `/read/[slug]` is redirected to Sanbase `/insights/read/[slug]`

**Note**: In Sanbase `/insights` routes are redirected to new `/__insights` routes

## Notion card
https://www.notion.so/santiment/Insights-home-page-on-Sanbase-1f42a82d1361808c9a56fafe79a3c9be?source=copy_link