### PR TITLE
fix(tooltip) Fix tooltips positioned incorrectly on new page

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -10,6 +10,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
 }
 
 .section {


### PR DESCRIPTION
## Summary
Fix incorrect tooltips (products and account dropdown) position on `/new` page

## Notion card
https://www.notion.so/santiment/Insights-design-review-fixes-25a2a82d136180fd9c93ee4de7289bcc?source=copy_link

## Screenshots
### The problem:
<img width="915" height="444" alt="image" src="https://github.com/user-attachments/assets/8c2f07d0-c77e-468a-8790-18ec794331ca" />


### Fixed:
<img width="617" height="788" alt="image" src="https://github.com/user-attachments/assets/79d87e06-11f5-47cc-9584-c30d6676d9b0" />
